### PR TITLE
Update xxxChannel#bulkDelete

### DIFF
--- a/discord.d.ts
+++ b/discord.d.ts
@@ -273,7 +273,7 @@ declare module "discord.js" {
         verificationLevel: number;
         voiceConnection: VoiceConnection;
         ban(user: GuildMember, deleteDays?: number): Promise<GuildMember | User | string>;
-        createChannel(name: string, type: 'text' | 'voice'): Promise<TextChannel | VoiceChannel>;
+        createChannel(name: string, type: "text" | "voice"): Promise<TextChannel | VoiceChannel>;
         createRole(data?: {}): Promise<Role>;
         delete(): Promise<Guild>;
         edit(data: {}): Promise<Guild>;

--- a/discord.d.ts
+++ b/discord.d.ts
@@ -154,7 +154,7 @@ declare module "discord.js" {
         typing: boolean;
         typingCount: number;
         awaitMessages(filter: CollectorFilterFunction, options?: AwaitMessagesOptions): Promise<Collection<string, Message>>;
-        bulkDelete(messages: Collection<string, Message> | Message[]): Collection<string, Message>;
+        bulkDelete(messages: Collection<string, Message> | Message[] | number): Collection<string, Message>;
         createCollector(filter: CollectorFilterFunction, options?: CollectorOptions): MessageCollector;
         fetchMessage(messageID: string): Promise<Message>;
         fetchMessages(options?: ChannelLogsQueryOptions): Promise<Collection<string, Message>>;
@@ -175,7 +175,7 @@ declare module "discord.js" {
         typing: boolean;
         typingCount: number;
         awaitMessages(filter: CollectorFilterFunction, options?: AwaitMessagesOptions): Promise<Collection<string, Message>>;
-        bulkDelete(messages: Collection<string, Message> | Message[]): Collection<string, Message>;
+        bulkDelete(messages: Collection<string, Message> | Message[] | number): Collection<string, Message>;
         createCollector(filter: CollectorFilterFunction, options?: CollectorOptions): MessageCollector;
         fetchMessage(messageID: string): Promise<Message>;
         fetchMessages(options?: ChannelLogsQueryOptions): Promise<Collection<string, Message>>;
@@ -210,7 +210,7 @@ declare module "discord.js" {
         typing: boolean;
         typingCount: number;
         awaitMessages(filter: CollectorFilterFunction, options?: AwaitMessagesOptions): Promise<Collection<string, Message>>;
-        bulkDelete(messages: Collection<string, Message> | Message[]): Collection<string, Message>;
+        bulkDelete(messages: Collection<string, Message> | Message[] | number): Collection<string, Message>;
         createCollector(filter: CollectorFilterFunction, options?: CollectorOptions): MessageCollector;
         fetchMessage(messageID: string): Promise<Message>;
         fetchMessages(options?: ChannelLogsQueryOptions): Promise<Collection<string, Message>>;


### PR DESCRIPTION
[Documentation](https://discord.js.org/#!/docs/tag/master/class/TextChannel?scrollto=bulkDelete) states that each `bulkDelete` accepts a number as an argument, as an alternative to fetching messages.