### PR TITLE
Typings for #1211 and #1329

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -245,6 +245,7 @@ declare module 'discord.js' {
 		defaultChannel: TextChannel;
 		embedEnabled: boolean;
 		emojis: Collection<string, Emoji>;
+		explicitContentFilter: number;
 		features: object[];
 		icon: string;
 		iconURL: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -177,6 +177,7 @@ declare module 'discord.js' {
 		randomKey(): K;
 		reduce<T>(fn: (accumulator: any, value: V, key: K, collection: Collection<K, V>) => T, initialValue?: any): T;
 		some(fn: (value: V, key: K, collection: Collection<K, V>) => boolean, thisArg?: any): boolean;
+		sort(compareFunction?: (a: [K, V], b: [K, V]) => number): Collection<K, V>;
 	}
 
 	export class DMChannel extends TextBasedChannel(Channel) {
@@ -232,6 +233,7 @@ declare module 'discord.js' {
 
 	export class Guild {
 		constructor(client: Client, data: object);
+		_sortedRoles: Collection<string, Role>;
 		afkChannelID: string;
 		afkTimeout: number;
 		applicationID: string;
@@ -262,6 +264,8 @@ declare module 'discord.js' {
 		splashURL: string;
 		verificationLevel: number;
 		voiceConnection: VoiceConnection;
+		_sortedChannels(type: 'text' | 'voice'): Collection<string, TextChannel | VoiceChannel>;
+		_sortChannelPositionWithID(collection: Collection<string, any>);
 		acknowledge(): Promise<Guild>;
 		addMember(user: UserResolvable, options: AddGuildMemberOptions): Promise<GuildMember>;
 		ban(user: UserResolvable, deleteDays?: number): Promise<GuildMember | User | string>;
@@ -282,9 +286,10 @@ declare module 'discord.js' {
 		member(user: UserResolvable): GuildMember;
 		pruneMembers(days: number, dry?: boolean): Promise<number>;
 		search(options?: MessageSearchOptions): Promise<Message[][]>;
-		setAFKChannel(afkChannel: ChannelResovalble): Promise<Guild>;
+		setAFKChannel(afkChannel: ChannelResolvable): Promise<Guild>;
 		setAFKTimeout(afkTimeout: number): Promise<Guild>;
-		setChannelPositions(channelPositions: ChannelPosition): Promise<Guild>;
+		setChannelPosition(channel: string | GuildChannel, position: number, relative?: boolean);
+		setChannelPositions(channelPositions: ChannelPosition[]): Promise<Guild>;
 		setIcon(icon: Base64Resolvable): Promise<Guild>;
 		setName(name: string): Promise<Guild>;
 		setOwner(owner: GuildMemberResolvable): Promise<Guild>;
@@ -299,6 +304,7 @@ declare module 'discord.js' {
 
 	export class GuildChannel extends Channel {
 		constructor(guild: Guild, data: object);
+		calculatedPosition: number;
 		deletable: boolean;
 		guild: Guild;
 		name: string;
@@ -311,7 +317,7 @@ declare module 'discord.js' {
 		overwritePermissions(userOrRole: RoleResolvable | UserResolvable, options: PermissionOverwriteOptions): Promise<void>;
 		permissionsFor(member: GuildMemberResolvable): Permissions;
 		setName(name: string): Promise<GuildChannel>;
-		setPosition(position: number): Promise<GuildChannel>;
+		setPosition(position: number, relative?: boolean): Promise<GuildChannel>;
 		setTopic(topic: string): Promise<GuildChannel>;
 		toString(): string;
 	}
@@ -358,14 +364,14 @@ declare module 'discord.js' {
 		hasPermissions(permission: PermissionResolvable[], explicit?: boolean): boolean;
 		kick(): Promise<GuildMember>;
 		missingPermissions(permissions: PermissionResolvable[], explicit?: boolean): PermissionResolvable[];
-		permissionsIn(channel: ChannelResovalble): Permissions;
+		permissionsIn(channel: ChannelResolvable): Permissions;
 		removeRole(role: Role | string): Promise<GuildMember>;
 		removeRoles(roles: Collection<string, Role> | Role[] | string[]): Promise<GuildMember>;
 		setDeaf(deaf: boolean): Promise<GuildMember>;
 		setMute(mute: boolean): Promise<GuildMember>;
 		setNickname(nickname: string): Promise<GuildMember>;
 		setRoles(roles: Collection<string, Role> | Role[] | string[]): Promise<GuildMember>;
-		setVoiceChannel(voiceChannel: ChannelResovalble): Promise<GuildMember>;
+		setVoiceChannel(voiceChannel: ChannelResolvable): Promise<GuildMember>;
 		toString(): string;
 	}
 
@@ -818,9 +824,9 @@ declare module 'discord.js' {
 		removeFriend(): Promise<User>;
 		setNote(note: string): Promise<User>;
 		toString(): string;
-		typingDurationIn(channel: ChannelResovalble): number;
-		typingIn(channel: ChannelResovalble): boolean;
-		typingSinceIn(channel: ChannelResovalble): Date;
+		typingDurationIn(channel: ChannelResolvable): number;
+		typingIn(channel: ChannelResolvable): boolean;
+		typingSinceIn(channel: ChannelResolvable): Date;
 		unblock(): Promise<User>;
 	}
 
@@ -1059,11 +1065,11 @@ declare module 'discord.js' {
 	};
 
 	type ChannelPosition = {
-		id: string;
+		channel: ChannelResolvable;
 		position: number;
 	};
 
-	type ChannelResovalble = Channel | Guild | Message | string;
+	type ChannelResolvable = Channel | Guild | Message | string;
 
 	type ClientOptions = {
 		apiRequestMethod?: string;
@@ -1144,7 +1150,7 @@ declare module 'discord.js' {
 		name?: string;
 		region?: string;
 		verificationLevel?: number;
-		afkChannel?: ChannelResovalble;
+		afkChannel?: ChannelResolvable;
 		afkTimeout?: number;
 		icon?: Base64Resolvable;
 		owner?: GuildMemberResolvable;
@@ -1190,7 +1196,7 @@ declare module 'discord.js' {
 			| '-video'
 			| '-image'
 			| '-sound';
-		channel?: ChannelResovalble;
+		channel?: ChannelResolvable;
 		author?: UserResolvable;
 		authorType?: 'user'
 			| 'bot'

--- a/index.d.ts
+++ b/index.d.ts
@@ -233,7 +233,6 @@ declare module 'discord.js' {
 
 	export class Guild {
 		constructor(client: Client, data: object);
-		_sortedRoles: Collection<string, Role>;
 		afkChannelID: string;
 		afkTimeout: number;
 		applicationID: string;
@@ -265,8 +264,6 @@ declare module 'discord.js' {
 		splashURL: string;
 		verificationLevel: number;
 		voiceConnection: VoiceConnection;
-		_sortedChannels(type: 'text' | 'voice'): Collection<string, TextChannel | VoiceChannel>;
-		_sortChannelPositionWithID(collection: Collection<string, any>);
 		acknowledge(): Promise<Guild>;
 		addMember(user: UserResolvable, options: AddGuildMemberOptions): Promise<GuildMember>;
 		ban(user: UserResolvable, deleteDays?: number): Promise<GuildMember | User | string>;


### PR DESCRIPTION
Added Typings for [#1211](https://github.com/hydrabolt/discord.js/pull/1211):
- Collection#sort
- ~~Guild#_sortedRoles~~
- ~~Guild#_sortedChannels~~
- ~~Guild#_sortChannelPositionWithID~~
- Guild#setChannelPositions
- ChannelPositions first argument is a ChannelResolveable
- Fixed typo ChannelResovalble -> ChannelResolvable

~~Not sure what to do with Guild#_sortChannelPositionWithID's collection, currently it's value is `any`.
Maybe `GuildChannel | Role` would be better?~~

Added Typings for [#1329](https://github.com/hydrabolt/discord.js/pull/1329)
- Guild#explicitContentFilter