### PR TITLE
Typings for MessageMentions class and User#tag

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -413,13 +413,7 @@ declare module 'discord.js' {
 		hit: boolean;
 		id: string;
 		member: GuildMember;
-		mentions: {
-			users: Collection<string, User>;
-			members: Collection<string, GuildMember>;
-			roles: Collection<string, Role>;
-			channels: Collection<string, GuildChannel>;
-			everyone: boolean;
-		};
+		mentions: MessageMentions;
 		nonce: string;
 		pinnable: boolean;
 		pinned: boolean;
@@ -547,6 +541,18 @@ declare module 'discord.js' {
 		height: number;
 		url: string;
 		width: number;
+	}
+
+	export class MessageMentions {
+		channels: Collection<string, GuildChannel>;
+		everyone: boolean;
+		members: Collection<string, GuildMember>;
+		roles: Collection<string, Role>;
+		users: Collection<string,User>;
+		static CHANNELS_PATTERN: RegExp;
+		static EVERYONE_PATTERN: RegExp;
+		static ROLES_PATTERN: RegExp;
+		static USERS_PATTERN: RegExp;
 	}
 
 	export class MessageReaction {

--- a/index.d.ts
+++ b/index.d.ts
@@ -819,6 +819,7 @@ declare module 'discord.js' {
 		note?: string;
 		presence: Presence;
 		username: string;
+		tag: string;
 		addFriend(): Promise<User>;
 		block(): Promise<User>;
 		createDM(): Promise<DMChannel>

--- a/index.d.ts
+++ b/index.d.ts
@@ -544,11 +544,11 @@ declare module 'discord.js' {
 	}
 
 	export class MessageMentions {
-		channels: Collection<string, GuildChannel>;
+		channels: Collection<string, TextChannel>;
 		everyone: boolean;
 		members: Collection<string, GuildMember>;
 		roles: Collection<string, Role>;
-		users: Collection<string,User>;
+		users: Collection<string, User>;
 		static CHANNELS_PATTERN: RegExp;
 		static EVERYONE_PATTERN: RegExp;
 		static ROLES_PATTERN: RegExp;


### PR DESCRIPTION
Typings for the MessageMentions class

From multiple commits: [compare here](https://github.com/hydrabolt/discord.js/compare/878e5d7...3bc90dc)
Or one by one:
- [#3bc90dc](https://github.com/hydrabolt/discord.js/commit/3bc90dcbf13f75ca59a5f66f37fb7ccd274c3d3b)
- [#ebcf61f](https://github.com/hydrabolt/discord.js/commit/ebcf61ff9c6731eb8373b1d804c9a611adc883c4) 
- [#4fa5cee](https://github.com/hydrabolt/discord.js/commit/4fa5ceed83e684adea560dc09480fb676321f6ed)
- [#fa016b6](https://github.com/hydrabolt/discord.js/commit/fa016b6b4178d18bf094646088a3d9f2d8c54a4d) 

A random merge appeared?
So be it:
User#tag: [#1351](https://github.com/hydrabolt/discord.js/pull/1351)