### PR TITLE
Typings for the new moderation stuff on API

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1472,6 +1472,7 @@ declare module 'discord.js' {
 		INVITE?: string;
 		WEBHOOK?: string;
 		EMOJI?: string;
+		MESSAGE?: string;
 	};
 
 	type GuildEditData = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1449,7 +1449,7 @@ declare module 'discord.js' {
 		name: string;
 		old: any;
 		new: any;
-	}
+	};
 
 	type GuildAuditLogsTarget = keyof GuildAuditLogsTargets;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1606,6 +1606,7 @@ declare module 'discord.js' {
 		MANAGE_CHANNELS?: boolean;
 		MANAGE_GUILD?: boolean;
 		ADD_REACTIONS?: boolean;
+		VIEW_AUDIT_LOG?: boolean;
 		READ_MESSAGES?: boolean;
 		SEND_MESSAGES?: boolean;
 		SEND_TTS_MESSAGES?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1304,8 +1304,8 @@ declare module 'discord.js' {
 
 	type AuditLogChange = {
 		key: string;
-		old?: string | boolean | number;
-		new?: string | boolean | number;
+		old?: any;
+		new?: any;
 	};
 
 	type AwaitMessagesOptions = MessageCollectorOptions & { errors?: string[] };

--- a/index.d.ts
+++ b/index.d.ts
@@ -421,7 +421,7 @@ declare module 'discord.js' {
 		constructor(guild: Guild, data: object);
 		public action: GuildAuditLogsAction;
 		public actionType: GuildAuditLogsActionType;
-		public changes?: object[];
+		public changes?: GuildAuditLogsEntryChange[];
 		public executor: User;
 		public extra?: object | Role | GuildMember;
 		public id: Snowflake;
@@ -1444,6 +1444,12 @@ declare module 'discord.js' {
 		| 'DELETE'
 		| 'UPDATE'
 		| 'ALL';
+
+	type GuildAuditLogsEntryChange = {
+		name: string;
+		old: any;
+		new: any;
+	}
 
 	type GuildAuditLogsTarget = keyof GuildAuditLogsTargets;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -378,7 +378,7 @@ declare module 'discord.js' {
 		public deleteEmoji(emoji: Emoji | string): Promise<void>;
 		public edit(data: GuildEditData): Promise<Guild>;
 		public equals(guild: Guild): boolean;
-		public fetchAuditLogs(options?: GuildFetchAuditLogsOptions): Promise<GuildAuditLogs>;
+		public fetchAuditLogs(options?: GuildAuditLogsFetchOptions): Promise<GuildAuditLogs>;
 		public fetchBans(): Promise<Collection<Snowflake, User>>;
 		public fetchInvites(): Promise<Collection<Snowflake, Invite>>;
 		public fetchMember(user: UserResolvable, cache?: boolean): Promise<GuildMember>;
@@ -1453,6 +1453,14 @@ declare module 'discord.js' {
 		new: any;
 	};
 
+	type GuildAuditLogsFetchOptions = {
+		before?: Snowflake | GuildAuditLogsEntry;
+		after?: Snowflake | GuildAuditLogsEntry;
+		limit?: number;
+		user?: UserResolvable;
+		type?: string | number;
+	};
+
 	type GuildAuditLogsTarget = keyof GuildAuditLogsTargets;
 
 	type GuildAuditLogsTargets = {
@@ -1474,14 +1482,6 @@ declare module 'discord.js' {
 		icon?: Base64Resolvable;
 		owner?: GuildMemberResolvable;
 		splash?: Base64Resolvable;
-	};
-
-	type GuildFetchAuditLogsOptions = {
-		before?: Snowflake | GuildAuditLogsEntry;
-		after?: Snowflake | GuildAuditLogsEntry;
-		limit?: number;
-		user?: UserResolvable;
-		type?: string | number;
 	};
 
 	type GuildMemberEditData = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -378,7 +378,7 @@ declare module 'discord.js' {
 		public deleteEmoji(emoji: Emoji | string): Promise<void>;
 		public edit(data: GuildEditData): Promise<Guild>;
 		public equals(guild: Guild): boolean;
-		public fetchAuditLogs(options: GuildFetchAuditLogsOptions): Promise<GuildAuditLogs>;
+		public fetchAuditLogs(options?: GuildFetchAuditLogsOptions): Promise<GuildAuditLogs>;
 		public fetchBans(): Promise<Collection<Snowflake, User>>;
 		public fetchInvites(): Promise<Collection<Snowflake, Invite>>;
 		public fetchMember(user: UserResolvable, cache?: boolean): Promise<GuildMember>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -421,7 +421,7 @@ declare module 'discord.js' {
 		constructor(guild: Guild, data: object);
 		public action: GuildAuditLogsAction;
 		public actionType: GuildAuditLogsActionType;
-		public changes?: GuildAuditLogsEntryChange[];
+		public changes?: AuditLogChange[];
 		public readonly createdTimestamp: number;
 		public readonly createdAt: Date;
 		public executor: User;
@@ -1302,6 +1302,12 @@ declare module 'discord.js' {
 		deaf?: boolean;
 	}
 
+	type AuditLogChange = {
+		key: string;
+		old?: string | boolean | number;
+		new?: string | boolean | number;
+	};
+
 	type AwaitMessagesOptions = MessageCollectorOptions & { errors?: string[] };
 
 	type AwaitReactionsOptions = ReactionCollectorOptions & { errors?: string[] };
@@ -1446,12 +1452,6 @@ declare module 'discord.js' {
 		| 'DELETE'
 		| 'UPDATE'
 		| 'ALL';
-
-	type GuildAuditLogsEntryChange = {
-		name: string;
-		old: any;
-		new: any;
-	};
 
 	type GuildAuditLogsFetchOptions = {
 		before?: Snowflake | GuildAuditLogsEntry;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1446,6 +1446,7 @@ declare module 'discord.js' {
 		EMOJI_CREATE?: number,
 		EMOJI_UPDATE?: number,
 		EMOJI_DELETE?: number,
+		MESSAGE_DELETE?: number,
 	};
 
 	type GuildAuditLogsActionType = 'CREATE'

--- a/index.d.ts
+++ b/index.d.ts
@@ -405,7 +405,7 @@ declare module 'discord.js' {
 		public unban(user: UserResolvable): Promise<User>;
 	}
 
-	class GuildAuditLogs {
+	export class GuildAuditLogs {
 		constructor(guild: Guild, data: object);
 		public entries: Collection<Snowflake, GuildAuditLogsEntry>;
 
@@ -422,6 +422,8 @@ declare module 'discord.js' {
 		public action: GuildAuditLogsAction;
 		public actionType: GuildAuditLogsActionType;
 		public changes?: GuildAuditLogsEntryChange[];
+		public readonly createdTimestamp: number;
+		public readonly createdAt: Date;
 		public executor: User;
 		public extra?: object | Role | GuildMember;
 		public id: Snowflake;


### PR DESCRIPTION
Typings for the result of PRs:
  - https://github.com/hydrabolt/discord.js/pull/1403 (First PR by Gus for new moderation stuff)
  - https://github.com/hydrabolt/discord.js/pull/1431 (PR by Gus "consistency")
  - https://github.com/hydrabolt/discord.js/pull/1435 (PR by Gus "extras")
  - https://github.com/hydrabolt/discord.js/pull/1436 (PR by Gus to set entries to collection)
  - https://github.com/hydrabolt/discord.js/pull/1443 (PR by Gus to add time getters)
  - https://github.com/hydrabolt/discord.js/pull/1456 (PR by Gus to add MESSAGE_DELETE action)
  - https://github.com/hydrabolt/discord.js/pull/1464 (PR by space to add MESSAGE target [& other stuff that don't change anything in the typings atm])

and commits:
  - https://github.com/hydrabolt/discord.js/commit/135d9e3ea0f45faa2f9f46f908d45a3cf11b6436 (Commit by Hydrabolt to expose GuildAuditLogs)
  - https://github.com/hydrabolt/discord.js/commit/7da53af0c383b080b0997e5507cb8e870821b446 (Commit by Hydrabolt to add AuditLogChange typedef)
  - https://github.com/hydrabolt/discord.js/commit/b7a81ed7e1dfbff2f46e66a09353311247a125a4 (Commit by Hydrabolt renaming 'name' to 'key' in AuditLogChange
  - https://github.com/hydrabolt/discord.js/commit/a7c902c6cfbd0a583f40d983a9f0e5d20cfa6e5d (Commit by Hydrabolt to set 'new' (AuditLogChange) to optional)

Includes:
  - kick & ban reasons;
  - ban options (days & reason);
  - fetching audit logs (for guilds);
  - audit logs;
  - audit logs permission;
  - audit logs entries.

Please tell me if I did something wrong.