### PR TITLE
Fixed Client#guildMembersChunk members parameter and PermissionResolvable type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -106,7 +106,7 @@ declare module 'discord.js' {
 		public on(event: 'guildMemberAdd', listener: (member: GuildMember) => void): this;
 		public on(event: 'guildMemberAvailable', listener: (member: GuildMember) => void): this;
 		public on(event: 'guildMemberRemove', listener: (member: GuildMember) => void): this;
-		public on(event: 'guildMembersChunk', listener: (members: Collection<Snowflake, GuildMember>, guild: Guild) => void): this;
+		public on(event: 'guildMembersChunk', listener: (members: GuildMember[], guild: Guild) => void): this;
 		public on(event: 'guildMemberSpeaking', listener: (member: GuildMember, speaking: boolean) => void): this;
 		public on(event: 'guildMemberUpdate', listener: (oldMember: GuildMember, newMember: GuildMember) => void): this;
 		public on(event: 'guildUnavailable', listener: (guild: Guild) => void): this;
@@ -1699,7 +1699,7 @@ declare module 'discord.js' {
 
 	type PermissionOverwriteOptions = PermissionObject;
 
-	type PermissionResolvable = PermissionString | PermissionString[] | number[];
+	type PermissionResolvable = PermissionString | number;
 
 	type PresenceData = {
 		status?: PresenceStatus;


### PR DESCRIPTION
`guildMembersChunk` does not emit an Collection before v12, see [here](https://github.com/hydrabolt/discord.js/pull/1734).

And PermissionResolveable does not accept an array of PermissionStrings or numbers

Since an array of those would allow something like this:
```ts
client.generateInvite([ ['SEND_MESSAGES'], ['READ_MESSAGES'] ]);
```