### PR TITLE
Add an author option for fetchMessages()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1522,6 +1522,7 @@ declare module 'discord.js' {
 		before?: Snowflake
 		after?: Snowflake
 		around?: Snowflake
+		author?: UserResolvable
 	};
 
 	type ChannelPosition = {


### PR DESCRIPTION
Just filters by author while fetching messages rather than needing to filter afterward. I'm still sort of new to this, so I'm not sure if it will mess anything up, which is why I'm creating a pull request.